### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,39 +14,39 @@ tm	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-isLeapYear		KEYWORD2
-daysInMonth		KEYWORD2
-dayOfYear		KEYWORD2
-mktime			KEYWORD2
-gmtime_r		KEYWORD2
-stopClock		KEYWORD2
-startClock		KEYWORD2
-readClock		KEYWORD2
-setClock		KEYWORD2
-getAddress		KEYWORD2
-setAddress		KEYWORD2
-setSQW			KEYWORD2
+isLeapYear	KEYWORD2
+daysInMonth	KEYWORD2
+dayOfYear	KEYWORD2
+mktime	KEYWORD2
+gmtime_r	KEYWORD2
+stopClock	KEYWORD2
+startClock	KEYWORD2
+readClock	KEYWORD2
+setClock	KEYWORD2
+getAddress	KEYWORD2
+setAddress	KEYWORD2
+setSQW	KEYWORD2
 enableBatteryBackup	KEYWORD2
 clearPowerFailFlag	KEYWORD2
-getCalibration		KEYWORD2
-setCalibration		KEYWORD2
+getCalibration	KEYWORD2
+setCalibration	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-DS1307			LITERAL1
-MCP7941x		LITERAL1
-PCF85263		LITERAL1
-DS1307Address		LITERAL1
-MCP7941xAddress		LITERAL1
+DS1307	LITERAL1
+MCP7941x	LITERAL1
+PCF85263	LITERAL1
+DS1307Address	LITERAL1
+MCP7941xAddress	LITERAL1
 MCP7941xEepromAddress	LITERAL1
-PCF85263Address		LITERAL1
-TIME			LITERAL1
-ALARM0			LITERAL1
-ALARM1			LITERAL1
+PCF85263Address	LITERAL1
+TIME	LITERAL1
+ALARM0	LITERAL1
+ALARM1	LITERAL1
 TIME_POWER_RESTORED	LITERAL1
 TIME_POWER_FAILED	LITERAL1
-freq1Hz			LITERAL1
-freq4096Hz		LITERAL1
-freq32768Hz		LITERAL1
-freqCalibration		LITERAL1
+freq1Hz	LITERAL1
+freq4096Hz	LITERAL1
+freq32768Hz	LITERAL1
+freqCalibration	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords